### PR TITLE
fix: guard null defaultChild dans boucle PITR DynamoDB

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -183,7 +183,8 @@ if (!isSandbox) {
   const tables = backend.data.resources.tables;
 
   Object.values(tables).forEach((table) => {
-    const cfnTable = table.node.defaultChild as CfnTable;
+    const cfnTable = table.node.defaultChild as CfnTable | undefined;
+    if (!cfnTable) return;
 
     cfnTable.pointInTimeRecoverySpecification = {
       pointInTimeRecoveryEnabled: true,


### PR DESCRIPTION
Certaines entrées de backend.data.resources.tables n'ont pas de defaultChild CfnTable — skip silencieux pour éviter le crash CDK.