### PR TITLE
fix: assigner post-confirmation-notify à la stack auth (dépendance ci…

### DIFF
--- a/amplify/functions/post-confirmation-notify/resource.ts
+++ b/amplify/functions/post-confirmation-notify/resource.ts
@@ -6,4 +6,5 @@ export const postConfirmationNotify = defineFunction({
   runtime: 22,
   timeoutSeconds: 10,
   memoryMB: 128,
+  resourceGroupName: 'auth',
 });


### PR DESCRIPTION
…rculaire CDK)

Le trigger PostConfirmation doit vivre dans la stack auth pour éviter la dépendance circulaire auth ↔ function détectée par CloudFormation.