### PR TITLE
fix: compteur de visites — vérification erreurs mutation + logging La…

### DIFF
--- a/amplify/functions/record-site-visit/handler.ts
+++ b/amplify/functions/record-site-visit/handler.ts
@@ -5,9 +5,12 @@ const ddbClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 
 export const handler = async () => {
   const tableName = process.env['SITE_VISIT_TABLE_NAME'];
+  console.log('[RecordSiteVisit] Table:', tableName);
+
   if (!tableName) throw new Error('SITE_VISIT_TABLE_NAME not set');
 
   const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
+  console.log('[RecordSiteVisit] Recording visit for:', today);
 
   const result = await ddbClient.send(
     new UpdateCommand({
@@ -21,5 +24,6 @@ export const handler = async () => {
   );
 
   const item = result.Attributes ?? {};
+  console.log('[RecordSiteVisit] Updated:', JSON.stringify(item));
   return { date: item['id'] ?? today, count: item['count'] ?? 1 };
 };

--- a/src/app/core/services/site-visit.service.ts
+++ b/src/app/core/services/site-visit.service.ts
@@ -17,9 +17,15 @@ export class SiteVisitService {
   async recordVisit(): Promise<void> {
     if (sessionStorage.getItem('ecnelis_visit_recorded')) return;
     try {
-      await (this.amplifyService.client as any).mutations.recordSiteVisitMutation({
+      const result: any = await (this.amplifyService.client as any).mutations.recordSiteVisitMutation({
         authMode: 'apiKey',
       });
+
+      if (result?.errors?.length) {
+        console.error('[SiteVisit] recordVisit mutation errors:', result.errors);
+        return; // Don't set sessionStorage — retry on next load
+      }
+
       sessionStorage.setItem('ecnelis_visit_recorded', '1');
     } catch (e) {
       console.warn('[SiteVisit] recordVisit failed:', e);
@@ -37,6 +43,12 @@ export class SiteVisitService {
         nextToken,
         authMode: 'apiKey',
       });
+
+      if (result?.errors?.length) {
+        console.error('[SiteVisit] getVisitStats errors:', result.errors);
+        break;
+      }
+
       for (const item of result.data ?? []) {
         if (!item) continue;
         allVisits.push({ id: item.id, count: item.count ?? 0 });


### PR DESCRIPTION
…mbda

Le client Amplify Gen2 ne throw pas en cas d'erreur de mutation, il retourne { data, errors }. Le sessionStorage était marqué même en cas d'échec silencieux, empêchant les retentatives.