### PR TITLE
fix: Lambda écrit __typename/createdAt/updatedAt + selectionSet pour …

### DIFF
--- a/amplify/functions/record-site-visit/handler.ts
+++ b/amplify/functions/record-site-visit/handler.ts
@@ -16,9 +16,19 @@ export const handler = async () => {
     new UpdateCommand({
       TableName: tableName,
       Key: { id: today },
-      UpdateExpression: 'SET #count = if_not_exists(#count, :zero) + :inc',
-      ExpressionAttributeNames: { '#count': 'count' },
-      ExpressionAttributeValues: { ':zero': 0, ':inc': 1 },
+      UpdateExpression: 'SET #count = if_not_exists(#count, :zero) + :inc, #typename = :typename, #createdAt = if_not_exists(#createdAt, :now), #updatedAt = :now',
+      ExpressionAttributeNames: {
+        '#count': 'count',
+        '#typename': '__typename',
+        '#createdAt': 'createdAt',
+        '#updatedAt': 'updatedAt',
+      },
+      ExpressionAttributeValues: {
+        ':zero': 0,
+        ':inc': 1,
+        ':typename': 'SiteVisit',
+        ':now': new Date().toISOString(),
+      },
       ReturnValues: 'ALL_NEW',
     }),
   );

--- a/src/app/core/services/site-visit.service.ts
+++ b/src/app/core/services/site-visit.service.ts
@@ -41,6 +41,7 @@ export class SiteVisitService {
       const result: any = await (this.amplifyService.client as any).models.SiteVisit.list({
         limit: 500,
         nextToken,
+        selectionSet: ['id', 'count'],
         authMode: 'apiKey',
       });
 


### PR DESCRIPTION
…lire les items

AppSync exige createdAt/updatedAt (AWSDateTime non-nullable) sur SiteVisit. La Lambda n'écrivait que id/count → items invisibles pour AppSync. Ajout selectionSet: ['id', 'count'] côté lecture pour tolérer les anciens items.