### PR TITLE
feat: stepper élargi, carte plein écran, création utilisateur admin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1419,6 +1419,46 @@ Cles `toolbar.admin.users` + `admin.users.*` (~80 cles) : title, subtitle, expor
 
 De plus, des listeners `valueChanges` (debounce 300ms) sur les champs `title` et `shortStory` appellent `emitCompleted()` pour garder le parent a jour en continu.
 
+## Stepper ajout de son — layout desktop elargi
+
+### Largeurs
+
+| Fichier | max-width |
+|---------|-----------|
+| `new-sound.component.scss` `:host` | `1200px` |
+| `place-step.component.scss` `.place-step-container` | `1000px` |
+| `sound-data-info-step.component.scss` | `1000px` |
+| `sound-data-meta-step.component.scss` | `1000px` |
+| `sound-upload-step.component.scss` | `1000px` |
+| `confirmation-step.component.scss` | `1000px` |
+
+### Carte plein ecran (place-step)
+
+Bouton `fullscreen` / `fullscreen_exit` en haut a droite de la carte, visible uniquement en desktop (`@media min-width: 701px`). Signal `mapExpanded` dans `place-step.component.ts`.
+
+**Mode expanse :**
+- `.map-card.map-expanded` : `position: fixed; inset: 0; z-index: 900` — carte couvre tout le viewport
+- `.place-name-card` : `position: fixed; bottom: 58px; z-index: 901` — input superpose en glassmorphism
+- `.stepper-actions` : `position: fixed; bottom: 0; z-index: 902` — boutons prev/next en glassmorphism
+- `.instructions-card` : masquee
+- `.map-overlay-hint` : repositionnee a `bottom: 146px` (au-dessus des controles)
+- Selecteur sibling : `app-place-step:has(.map-expanded) ~ .stepper-actions` (ViewEncapsulation.None)
+
+**Auto-collapse :** `onStepChange()` dans `new-sound.component.ts` reset `placeStep.mapExpanded` quand on quitte le step 1. `@ViewChild('placeStep')` pour acceder au composant.
+
+**Mobile :** bouton masque (`display: none`), pas d'impact.
+
+### Creation d'utilisateur admin (sound-data-meta-step)
+
+Bouton "Creer un utilisateur" dans l'etape metadonnees (admin uniquement). Formulaire inline avec :
+- Champ username (requis, unicite verifiee)
+- Champ pays (autocomplete `i18n-iso-countries` avec preview drapeau)
+- Email genere : `imported_{sanitized}@imported.local`
+- ID : `crypto.randomUUID()`
+- Backend : `User` model autorise `create` pour le groupe ADMIN
+
+**i18n :** cles `sound.admin.*` (create-user, new-username, country, create-btn, user-created, user-create-error, username-exists)
+
 ## Admin icon — Hub listener
 
 Le signal `isAdmin` dans `app.component.ts` est mis a jour dans le handler Hub `signedIn` (pas seulement dans `ngOnInit`) via `await authService.loadCurrentUser()` + `isAdmin.set(authService.isInGroup('ADMIN'))`. Reset a `false` dans le handler `signedOut`.

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -81,7 +81,7 @@ const schema = a
         allow.publicApiKey().to(['read']),
         allow.authenticated().to(['read', 'update']),
         allow.guest().to(['read']),
-        allow.groups(['ADMIN']).to(['read', 'update', 'delete']),
+        allow.groups(['ADMIN']).to(['create', 'read', 'update', 'delete']),
       ]),
 
     Sound: a

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -484,7 +484,14 @@
       "user-section": "User Assignment",
       "linked-user": "User",
       "search-user": "Search for a user",
-      "linked-user-hint": "Select the user to whom this sound will be assigned"
+      "linked-user-hint": "Select the user to whom this sound will be assigned",
+      "create-user": "Create a user",
+      "new-username": "Username",
+      "country": "Country",
+      "create-btn": "Create",
+      "user-created": "User created",
+      "user-create-error": "Error creating user",
+      "username-exists": "This name already exists"
     }
   },
   "admin": {

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -478,7 +478,14 @@
       "user-section": "Usuario a vincular",
       "linked-user": "Usuario",
       "search-user": "Buscar un usuario",
-      "linked-user-hint": "Seleccione el usuario al que se asignará este sonido"
+      "linked-user-hint": "Seleccione el usuario al que se asignará este sonido",
+      "create-user": "Crear un usuario",
+      "new-username": "Nombre de usuario",
+      "country": "País",
+      "create-btn": "Crear",
+      "user-created": "Usuario creado",
+      "user-create-error": "Error al crear",
+      "username-exists": "Este nombre ya existe"
     }
   },
   "admin": {

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -484,7 +484,14 @@
       "user-section": "Utilisateur à lier",
       "linked-user": "Utilisateur",
       "search-user": "Rechercher un utilisateur",
-      "linked-user-hint": "Sélectionnez l'utilisateur auquel ce son sera attribué"
+      "linked-user-hint": "Sélectionnez l'utilisateur auquel ce son sera attribué",
+      "create-user": "Créer un utilisateur",
+      "new-username": "Nom d'utilisateur",
+      "country": "Pays",
+      "create-btn": "Créer",
+      "user-created": "Utilisateur créé",
+      "user-create-error": "Erreur lors de la création",
+      "username-exists": "Ce nom existe déjà"
     }
   },
   "admin": {

--- a/src/app/features/new-sound/pages/new-sound/new-sound.component.html
+++ b/src/app/features/new-sound/pages/new-sound/new-sound.component.html
@@ -134,7 +134,7 @@
   [class.highlight-step-1]="isStepHighlighted(1)"
   [class.highlight-step-2]="isStepHighlighted(2)"
   [orientation]="(stepperOrientation | async)!"
-  (selectionChange)="currentStepIndex.set($event.selectedIndex)"
+  (selectionChange)="onStepChange($event.selectedIndex)"
 >
   <!-- Step 1 : upload sound-->
   <mat-step class="mat-step-content step-0" [completed]="soundUploaded()">
@@ -159,7 +159,7 @@
       {{ "sound.place-title" | translate }}
     </ng-template>
 
-    <app-place-step (placeSelected)="onPlaceSelected($event)"></app-place-step>
+    <app-place-step #placeStep (placeSelected)="onPlaceSelected($event)"></app-place-step>
 
     <div class="stepper-actions">
       <button mat-button matStepperPrevious>

--- a/src/app/features/new-sound/pages/new-sound/new-sound.component.scss
+++ b/src/app/features/new-sound/pages/new-sound/new-sound.component.scss
@@ -1,7 +1,7 @@
 :host {
   display: block;
   width: 100%;
-  max-width: 960px;
+  max-width: 1200px;
   margin: 16px auto;
   padding: 0 16px;
   box-sizing: border-box;

--- a/src/app/features/new-sound/pages/new-sound/new-sound.component.ts
+++ b/src/app/features/new-sound/pages/new-sound/new-sound.component.ts
@@ -63,6 +63,7 @@ export class NewSoundComponent implements OnInit, OnDestroy, AfterViewInit {
   private renderer = inject(Renderer2);
 
   @ViewChild(MatStepper) stepper!: MatStepper;
+  @ViewChild('placeStep') placeStep?: PlaceStepComponent;
 
   readonly soundUploaded = signal(false);
   readonly soundPath = signal<string | null>(null);
@@ -211,6 +212,11 @@ export class NewSoundComponent implements OnInit, OnDestroy, AfterViewInit {
     this.currentStepIndex.set(index);
     this.maxStepReached.update(max => Math.max(max, index));
 
+    // Collapse expanded map when leaving place step
+    if (index !== 1 && this.placeStep?.mapExpanded()) {
+      this.placeStep.mapExpanded.set(false);
+    }
+
     if (!this.isMobileWizard() && this.stepper) {
       this.stepper.selectedIndex = index;
     }
@@ -235,6 +241,14 @@ export class NewSoundComponent implements OnInit, OnDestroy, AfterViewInit {
 
     this.soundPath.set(path);
     this.soundUploaded.set(true);
+  }
+
+  onStepChange(index: number) {
+    this.currentStepIndex.set(index);
+    // Collapse expanded map when leaving place step
+    if (index !== 1 && this.placeStep?.mapExpanded()) {
+      this.placeStep.mapExpanded.set(false);
+    }
   }
 
   onPlaceSelected(place: PlaceSelection) {

--- a/src/app/features/new-sound/pages/new-sound/widgets/confirmation-step/confirmation-step.component.scss
+++ b/src/app/features/new-sound/pages/new-sound/widgets/confirmation-step/confirmation-step.component.scss
@@ -171,7 +171,7 @@
   flex-direction: column;
   gap: 20px;
   padding: 24px 16px;
-  max-width: 800px;
+  max-width: 1000px;
   margin: 0 auto;
 }
 

--- a/src/app/features/new-sound/pages/new-sound/widgets/place-step/place-step.component.html
+++ b/src/app/features/new-sound/pages/new-sound/widgets/place-step/place-step.component.html
@@ -11,9 +11,12 @@
   </div>
 
   <!-- Map container -->
-  <div class="map-card">
+  <div class="map-card" [class.map-expanded]="mapExpanded()">
     <div class="map-wrapper">
       <div id="map-newsound"></div>
+      <button class="map-expand-btn" (click)="toggleMapExpand()" type="button">
+        <mat-icon>{{ mapExpanded() ? 'fullscreen_exit' : 'fullscreen' }}</mat-icon>
+      </button>
       <div class="map-overlay-hint">
         <mat-icon>pin_drop</mat-icon>
         <span>{{ "sound.hint-marker" | translate }}</span>

--- a/src/app/features/new-sound/pages/new-sound/widgets/place-step/place-step.component.scss
+++ b/src/app/features/new-sound/pages/new-sound/widgets/place-step/place-step.component.scss
@@ -2,7 +2,7 @@
 
 .place-step-container {
   width: 100%;
-  max-width: 800px;
+  max-width: 1000px;
   margin: 0 auto;
   padding: 24px 16px;
   display: flex;
@@ -74,6 +74,134 @@
   position: relative;
   border-radius: 16px;
   overflow: hidden;
+  transition: height 0.3s ease;
+}
+
+// Expand/collapse button — desktop only
+.map-expand-btn {
+  display: none;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 500;
+  width: 34px;
+  height: 34px;
+  border: none;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(10px);
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  transition: background 0.2s, box-shadow 0.2s;
+
+  mat-icon {
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+    color: #555;
+  }
+
+  &:hover {
+    background: rgba(255, 255, 255, 1);
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2);
+
+    mat-icon {
+      color: #1976d2;
+    }
+  }
+}
+
+@media (min-width: 701px) {
+  .map-expand-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  // === Fullscreen map overlay ===
+  .map-card.map-expanded {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 900;
+    border-radius: 0;
+    box-shadow: none;
+
+    .map-wrapper {
+      height: 100% !important;
+      border-radius: 0;
+    }
+
+    .map-expand-btn {
+      z-index: 910;
+      top: 16px;
+      right: 16px;
+      width: 40px;
+      height: 40px;
+
+      mat-icon {
+        font-size: 24px;
+        width: 24px;
+        height: 24px;
+      }
+    }
+
+    .map-overlay-hint {
+      bottom: 146px;
+    }
+  }
+
+  // Hide instructions + overlay the input on the map
+  .place-step-container:has(.map-expanded) {
+    .instructions-card {
+      display: none;
+    }
+
+    .place-name-card {
+      position: fixed;
+      bottom: 58px;
+      left: 24px;
+      right: 24px;
+      z-index: 901;
+      background: rgba(255, 255, 255, 0.92);
+      backdrop-filter: blur(12px);
+      border-radius: 12px;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+      padding: 10px 20px;
+      margin: 0;
+    }
+  }
+
+  // Stepper prev/next buttons overlay at map bottom
+  app-place-step:has(.map-expanded) ~ .stepper-actions {
+    position: fixed !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    z-index: 902 !important;
+    margin-top: 0 !important;
+    padding: 8px 24px !important;
+    background: rgba(255, 255, 255, 0.95) !important;
+    backdrop-filter: blur(12px) !important;
+    border-top: 1px solid rgba(0, 0, 0, 0.1) !important;
+    border-radius: 0 !important;
+  }
+
+  // Dark mode overrides for fullscreen overlay
+  body.dark-theme {
+    .place-step-container:has(.map-expanded) .place-name-card {
+      background: rgba(22, 22, 38, 0.92) !important;
+      border-color: rgba(255, 255, 255, 0.1) !important;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+    }
+
+    app-place-step:has(.map-expanded) ~ .stepper-actions {
+      background: rgba(22, 22, 38, 0.95) !important;
+      border-top-color: rgba(255, 255, 255, 0.08) !important;
+    }
+  }
 }
 
 #map-newsound {
@@ -185,6 +313,22 @@ body.dark-theme {
     color: rgba(255, 255, 255, 0.7);
   }
 
+  .map-expand-btn {
+    background: rgba(30, 30, 48, 0.88);
+
+    mat-icon {
+      color: #9a9ab0;
+    }
+
+    &:hover {
+      background: rgba(40, 40, 60, 0.95);
+
+      mat-icon {
+        color: #90caf9;
+      }
+    }
+  }
+
   .place-name-card {
     background: #1f1f2f !important;
     border: 1px solid rgba(255, 255, 255, 0.08) !important;
@@ -196,6 +340,13 @@ body.dark-theme {
       border-color: rgba(255, 255, 255, 0.15) !important;
       box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
     }
+  }
+}
+
+// Taller map on wide desktop screens
+@media (min-width: 1100px) {
+  .map-wrapper {
+    height: 520px;
   }
 }
 

--- a/src/app/features/new-sound/pages/new-sound/widgets/place-step/place-step.component.ts
+++ b/src/app/features/new-sound/pages/new-sound/widgets/place-step/place-step.component.ts
@@ -40,6 +40,13 @@ export class PlaceStepComponent implements AfterViewInit, OnDestroy {
   private geoSearchService = inject(GeoSearchService);
 
   nameSelection = signal<string>('');
+  mapExpanded = signal(false);
+
+  toggleMapExpand() {
+    this.mapExpanded.update((v) => !v);
+    // Leaflet needs invalidateSize after container resize
+    setTimeout(() => this.map?.invalidateSize(), 350);
+  }
 
   ngAfterViewInit() {
     this.initMap();

--- a/src/app/features/new-sound/pages/new-sound/widgets/sound-data-info-step/sound-data-info-step.component.scss
+++ b/src/app/features/new-sound/pages/new-sound/widgets/sound-data-info-step/sound-data-info-step.component.scss
@@ -1,6 +1,6 @@
 .data-step-container {
   width: 100%;
-  max-width: 800px;
+  max-width: 1000px;
   margin: 0 auto;
   padding: 24px 16px;
   display: flex;

--- a/src/app/features/new-sound/pages/new-sound/widgets/sound-data-meta-step/sound-data-meta-step.component.html
+++ b/src/app/features/new-sound/pages/new-sound/widgets/sound-data-meta-step/sound-data-meta-step.component.html
@@ -242,6 +242,58 @@
             </mat-autocomplete>
             <mat-hint>{{ "sound.admin.linked-user-hint" | translate }}</mat-hint>
           </mat-form-field>
+
+          <!-- Create new user toggle -->
+          @if (!showCreateUser()) {
+            <button mat-button class="create-user-btn" (click)="showCreateUser.set(true)">
+              <mat-icon>person_add</mat-icon>
+              {{ 'sound.admin.create-user' | translate }}
+            </button>
+          }
+
+          <!-- Create new user inline form -->
+          @if (showCreateUser()) {
+            <div class="create-user-form">
+              <div class="create-user-fields">
+                <mat-form-field appearance="outline" class="create-field">
+                  <mat-label>{{ 'sound.admin.new-username' | translate }}</mat-label>
+                  <input matInput [formControl]="newUsername" />
+                  <mat-icon matSuffix>person</mat-icon>
+                </mat-form-field>
+
+                <div class="country-field-wrap">
+                  <mat-form-field appearance="outline" class="create-field">
+                    <mat-label>{{ 'sound.admin.country' | translate }}</mat-label>
+                    <input matInput [formControl]="newCountryCode" [matAutocomplete]="countryAuto" />
+                    <mat-icon matSuffix>public</mat-icon>
+                    <mat-autocomplete #countryAuto="matAutocomplete">
+                      @for (c of filteredCountries(); track c.code) {
+                        <mat-option [value]="c.code">
+                          <img [src]="getFlagPath(c.code)" width="20" height="14" style="vertical-align: middle; margin-right: 8px;" />
+                          {{ c.name }}
+                        </mat-option>
+                      }
+                    </mat-autocomplete>
+                  </mat-form-field>
+                  @if (getFlagPath(newCountryCode.value)) {
+                    <img class="flag-preview" [src]="getFlagPath(newCountryCode.value)" alt="" />
+                  }
+                </div>
+              </div>
+
+              <div class="create-user-actions">
+                <button mat-button (click)="cancelCreateUser()">
+                  {{ 'common.cancel' | translate }}
+                </button>
+                <button mat-raised-button color="primary" (click)="createNewUser()" [disabled]="creatingUser() || !newUsername.value?.trim()">
+                  @if (creatingUser()) {
+                    <mat-icon class="spin-icon">sync</mat-icon>
+                  }
+                  {{ 'sound.admin.create-btn' | translate }}
+                </button>
+              </div>
+            </div>
+          }
         </div>
       </div>
     }

--- a/src/app/features/new-sound/pages/new-sound/widgets/sound-data-meta-step/sound-data-meta-step.component.scss
+++ b/src/app/features/new-sound/pages/new-sound/widgets/sound-data-meta-step/sound-data-meta-step.component.scss
@@ -1,6 +1,6 @@
 .data-step-container {
   width: 100%;
-  max-width: 800px;
+  max-width: 1000px;
   margin: 0 auto;
   padding: 24px 16px;
   display: flex;
@@ -318,6 +318,86 @@
   }
 }
 
+// Admin: Create new user
+.create-user-btn {
+  margin-top: 4px;
+  color: #7b1fa2;
+  font-weight: 500;
+
+  mat-icon {
+    margin-right: 4px;
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+.create-user-form {
+  margin-top: 8px;
+  padding: 16px;
+  border: 1px dashed rgba(156, 39, 176, 0.35);
+  border-radius: 12px;
+  background: rgba(156, 39, 176, 0.04);
+  animation: slideDown 0.25s ease;
+}
+
+.create-user-fields {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+
+  .create-field {
+    flex: 1;
+    min-width: 200px;
+  }
+}
+
+.country-field-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 200px;
+
+  .create-field {
+    flex: 1;
+  }
+}
+
+.flag-preview {
+  width: 28px;
+  height: 20px;
+  border-radius: 2px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.create-user-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.spin-icon {
+  animation: spin 1s linear infinite;
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+  margin-right: 4px;
+}
+
+@keyframes slideDown {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
 // Dark mode
 :host-context(.dark-theme) {
   .header-card {
@@ -444,6 +524,15 @@
     .user-email {
       color: rgba(255, 255, 255, 0.5);
     }
+  }
+
+  .create-user-btn {
+    color: #ce93d8;
+  }
+
+  .create-user-form {
+    border-color: rgba(206, 147, 216, 0.3);
+    background: rgba(156, 39, 176, 0.1);
   }
 }
 

--- a/src/app/features/new-sound/pages/new-sound/widgets/sound-upload-step/sound-upload-step.component.scss
+++ b/src/app/features/new-sound/pages/new-sound/widgets/sound-upload-step/sound-upload-step.component.scss
@@ -1,6 +1,6 @@
 .step-container {
   width: 100%;
-  max-width: 800px;
+  max-width: 1000px;
   margin: 0 auto;
   padding: 24px 16px;
   display: flex;


### PR DESCRIPTION
- Stepper desktop élargi (960→1200px host, 800→1000px steps)
- Carte lieu : bouton fullscreen avec overlay plein écran (position fixed), input et boutons prev/next superposés en glassmorphism, auto-collapse au changement de step
- Admin : création d'utilisateur inline (username + pays autocomplete avec drapeaux) dans l'étape métadonnées
- Backend : ajout permission 'create' sur User pour groupe ADMIN
- i18n FR/EN/ES pour les nouvelles fonctionnalités