### PR TITLE
fix: traduction renforcée + utilisateur admin + bouton traduction edi…

### DIFF
--- a/src/app/features/dashboard/pages/dashboard/widgets/sound-edit-dialog/sound-edit-dialog.component.html
+++ b/src/app/features/dashboard/pages/dashboard/widgets/sound-edit-dialog/sound-edit-dialog.component.html
@@ -17,37 +17,69 @@
         <div class="tab-content">
           <form [formGroup]="infoForm" class="form-grid">
             <!-- Title -->
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ "sound.title" | translate }}</mat-label>
-              <input
-                matInput
-                formControlName="title"
-                [placeholder]="'sound.title-placeholder' | translate"
-                (blur)="translateField('title')"
-              />
-              <mat-icon matSuffix>title</mat-icon>
-              @if (translatingTitle()) {
-                <mat-spinner matSuffix diameter="20"></mat-spinner>
-              }
-              @if (infoForm.get('title')?.hasError('required')) {
-                <mat-error>{{ "sound.validation.title" | translate }}</mat-error>
-              }
-            </mat-form-field>
+            <div class="field-with-translate">
+              <mat-form-field appearance="outline" class="full-width">
+                <mat-label>{{ "sound.title" | translate }}</mat-label>
+                <input
+                  matInput
+                  formControlName="title"
+                  [placeholder]="'sound.title-placeholder' | translate"
+                  (blur)="translateField('title')"
+                />
+                <mat-icon matSuffix>title</mat-icon>
+                @if (translatingTitle()) {
+                  <mat-spinner matSuffix diameter="20"></mat-spinner>
+                }
+                @if (infoForm.get('title')?.hasError('required')) {
+                  <mat-error>{{ "sound.validation.title" | translate }}</mat-error>
+                }
+              </mat-form-field>
+              <button
+                mat-mini-fab
+                color="accent"
+                type="button"
+                class="translate-btn"
+                [disabled]="infoForm.get('title')?.invalid || translatingTitle()"
+                (click)="openTranslationDialog('title')"
+                [matTooltip]="'common.action.translate' | translate">
+                @if (translatingTitle()) {
+                  <mat-icon class="spinning">sync</mat-icon>
+                } @else {
+                  <mat-icon>translate</mat-icon>
+                }
+              </button>
+            </div>
 
             <!-- Short Story -->
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>{{ "sound.short-story" | translate }}</mat-label>
-              <textarea
-                matInput
-                formControlName="shortStory"
-                rows="3"
-                [placeholder]="'sound.short-story-placeholder' | translate"
-                (blur)="translateField('shortStory')"
-              ></textarea>
-              @if (translatingStory()) {
-                <mat-spinner matSuffix diameter="20"></mat-spinner>
-              }
-            </mat-form-field>
+            <div class="field-with-translate">
+              <mat-form-field appearance="outline" class="full-width">
+                <mat-label>{{ "sound.short-story" | translate }}</mat-label>
+                <textarea
+                  matInput
+                  formControlName="shortStory"
+                  rows="3"
+                  [placeholder]="'sound.short-story-placeholder' | translate"
+                  (blur)="translateField('shortStory')"
+                ></textarea>
+                @if (translatingStory()) {
+                  <mat-spinner matSuffix diameter="20"></mat-spinner>
+                }
+              </mat-form-field>
+              <button
+                mat-mini-fab
+                color="accent"
+                type="button"
+                class="translate-btn"
+                [disabled]="translatingStory()"
+                (click)="openTranslationDialog('shortStory')"
+                [matTooltip]="'common.action.translate' | translate">
+                @if (translatingStory()) {
+                  <mat-icon class="spinning">sync</mat-icon>
+                } @else {
+                  <mat-icon>translate</mat-icon>
+                }
+              </button>
+            </div>
 
             <!-- Category -->
             <mat-form-field appearance="outline">

--- a/src/app/features/dashboard/pages/dashboard/widgets/sound-edit-dialog/sound-edit-dialog.component.scss
+++ b/src/app/features/dashboard/pages/dashboard/widgets/sound-edit-dialog/sound-edit-dialog.component.scss
@@ -77,6 +77,41 @@ mat-dialog-content {
   }
 }
 
+// Translate button next to field
+.field-with-translate {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  grid-column: 1 / -1;
+
+  mat-form-field {
+    flex: 1;
+  }
+
+  .translate-btn {
+    flex-shrink: 0;
+    margin-top: 8px;
+    width: 36px;
+    height: 36px;
+
+    mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+    }
+
+    .spinning {
+      animation: spin 1s linear infinite;
+    }
+  }
+}
+
+@keyframes spin {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
 // Map container
 .map-container {
   margin-bottom: 16px;

--- a/src/app/features/dashboard/services/dashboard.service.ts
+++ b/src/app/features/dashboard/services/dashboard.service.ts
@@ -18,6 +18,36 @@ export class DashboardService {
    * Handles pagination with nextToken to load all sounds
    */
   async loadUserSounds(userId: string): Promise<Sound[]> {
+    const selectionSet = [
+      'id',
+      'userId',
+      'user.username',
+      'user.country',
+      'title',
+      'title_i18n',
+      'shortStory',
+      'shortStory_i18n',
+      'filename',
+      'status',
+      'latitude',
+      'longitude',
+      'city',
+      'category',
+      'secondaryCategory',
+      'dateTime',
+      'recordDateTime',
+      'equipment',
+      'license',
+      'url',
+      'urlTitle',
+      'secondaryUrl',
+      'secondaryUrlTitle',
+      'hashtags',
+      'likesCount',
+      'createdAt',
+      'updatedAt',
+    ] as const;
+
     try {
       const allSounds: Sound[] = [];
       let nextToken: string | null | undefined = undefined;
@@ -28,6 +58,7 @@ export class DashboardService {
           this.amplifyService.client.models.Sound.listSoundsByUserAndStatus as any
         )({
           userId,
+          selectionSet,
           limit: 100,
           nextToken,
         });

--- a/src/app/features/new-sound/pages/new-sound/new-sound.component.ts
+++ b/src/app/features/new-sound/pages/new-sound/new-sound.component.ts
@@ -116,6 +116,8 @@ export class NewSoundComponent implements OnInit, OnDestroy, AfterViewInit {
   soundInfoData: any = {};
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   soundMetaData: any = {};
+  /** Source language detected from user input (passed through to confirmation step) */
+  sourceLang: string | undefined;
 
   constructor() {
     const breakpointObserver = inject(BreakpointObserver);
@@ -260,6 +262,7 @@ export class NewSoundComponent implements OnInit, OnDestroy, AfterViewInit {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onSoundDataInfoCompleted(data: any) {
     this.soundInfoData = data;
+    this.sourceLang = data.sourceLang;
     // Marquer stepGroup valide si nécessaire
     this.thirdFormGroup.setValue({ thirdCtrl: '' });
   }
@@ -278,6 +281,7 @@ export class NewSoundComponent implements OnInit, OnDestroy, AfterViewInit {
       place: this.selectedPlace(),
       ...this.soundInfoData,
       ...this.soundMetaData,
+      sourceLang: this.sourceLang,
     };
   }
 


### PR DESCRIPTION
…t dialog

- Détection langue source : le texte brut est associé à la bonne langue (pas à la langue UI), skip de la traduction source→source via AWS
- confirmation-step : le champ title/shortStory par défaut utilise la langue détectée (plus la langue UI)
- dashboard.service : loadUserSounds() inclut user.username/country (corrige l'affichage "-" dans la colonne utilisateur admin)
- sound-edit-dialog : ajout bouton traduction (T) pour titre et description, même pattern que le formulaire d'ajout de son