### PR TITLE
revert: retrait du chip sous-catégorie des popups et bottom sheet mapfly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1026,18 +1026,6 @@ Container stylise dans `map.scss` (desktop uniquement, absent du bottom sheet mo
 - Appelee dans les 3 callbacks `popupopen` (normal, featured, journey)
 - i18n : `mapfly.popup.readMore` / `mapfly.popup.readLess` (FR/EN/ES)
 
-#### Chip sous-categorie (popup desktop + bottom sheet mobile)
-
-Lien cliquable vers la carte filtree par sous-categorie, place entre le record-info et le badge licence. Present dans les 3 types de popup (normal, featured, journey) et le bottom sheet mobile.
-
-- **Contenu** : icone marker de la sous-categorie (`marker_{catTronquee}.png`) + label i18n traduit (`categories.{category}.{secondaryCategory}`)
-- **Couleur dynamique** : CSS `color-mix()` via `--chip-color` (couleur de la categorie parente). Fond teinte 10%/14% (light/dark), bordure 18%/22%, texte mixe
-- **Clic** : `window.location.href` vers `/mapfly?category={cat}&secondaryCategory={subCat}` (full reload, meme pattern que le lien username)
-- **Conditionnel** : n'apparait que si `secondaryCategory` existe et que la traduction i18n est trouvee
-- **Desktop** : methode `secondaryCategoryChipHtml(category, secondaryCategory)` genere le HTML (`<a class="popup-subcategory-chip">`)
-- **Mobile** : template Angular avec computed signals `secondaryCategoryLabel()`, `chipColor()`, `subcategoryIconSrc()` et methode `navigateToCategory()`
-- **Styles** : `.popup-subcategory-chip` dans `map.scss`, `.sheet-subcategory-chip` dans `sound-popup-sheet.component.scss`
-
 #### Anti-clustering popup (piege connu)
 
 Quand un marker passe dans un cluster pendant que sa popup est ouverte, Leaflet ferme la popup.

--- a/src/app/features/map/pages/mapfly/mapfly.component.ts
+++ b/src/app/features/map/pages/mapfly/mapfly.component.ts
@@ -901,7 +901,6 @@ export class MapflyComponent implements OnInit, OnDestroy {
             <div id="btn-container-shortStory-${s.filename}"></div>
             <div id="links-${s.filename}" class="popup-links"></div>
             <p id="record-info-${s.filename}" class="popup-record-info" style="font-style: italic; font-size: 0.9em; margin-top: 6px;"></p>
-            ${s.secondaryCategory && s.category ? this.secondaryCategoryChipHtml(s.category, s.secondaryCategory) : ''}
             ${s.license ? this.licenseBadgeHtml(s.license) : ''}
             <div class="ws-popup-player" id="ws-player-${s.filename}"></div>
             <div id="btn-container-${s.filename}" class="popup-btn-group">
@@ -1522,14 +1521,6 @@ export class MapflyComponent implements OnInit, OnDestroy {
     const tooltip = this.licenseTooltip(license);
     const tooltipSpan = tooltip ? `<span class="license-tooltip">${tooltip}</span>` : '';
     return `<span class="popup-license-badge"><span class="material-icons" style="font-size:14px;vertical-align:middle;margin-right:3px;">copyright</span>${label}${tooltipSpan}</span>`;
-  }
-
-  /** Génère le chip cliquable de sous-catégorie (navigue vers la carte filtrée) */
-  private secondaryCategoryChipHtml(category: string, secondaryCategory: string): string {
-    const label = this.translate.instant(`categories.${category}.${secondaryCategory}`);
-    const iconName = secondaryCategory.slice(0, -3); // dogfly → dog
-    const color = this.categoryColors[category] ?? '#1976d2';
-    return `<a class="popup-subcategory-chip" href="/mapfly?category=${encodeURIComponent(category)}&secondaryCategory=${encodeURIComponent(secondaryCategory)}" style="--chip-color: ${color}"><img src="img/markers/marker_${iconName}.png" class="subcategory-chip-icon" alt="" /><span>${label}</span></a>`;
   }
 
   private parseI18n(field?: string | Record<string, string>) {
@@ -2365,7 +2356,6 @@ export class MapflyComponent implements OnInit, OnDestroy {
         <div id="btn-container-shortStory-${soundFilename}"></div>
         <div id="links-${soundFilename}" class="popup-links"></div>
         <p id="record-info-${soundFilename}" class="popup-record-info" style="font-style: italic; font-size: 0.9em; margin-top: 6px;"></p>
-        ${s?.secondaryCategory && s?.category ? this.secondaryCategoryChipHtml(s.category, s.secondaryCategory) : ''}
         ${s?.license ? this.licenseBadgeHtml(s.license) : ''}
         <div class="ws-popup-player" id="ws-player-featured-${soundFilename}"></div>
         <div id="btn-container-${soundFilename}" class="popup-btn-group">
@@ -2867,7 +2857,6 @@ export class MapflyComponent implements OnInit, OnDestroy {
         <div id="journey-translate-container-${stepIndex}"></div>
         <div id="journey-links-${stepIndex}" class="popup-links"></div>
         <p id="journey-record-info-${stepIndex}" class="popup-record-info" style="font-style: italic; font-size: 0.9em; margin-top: 6px;"></p>
-        ${sound.secondaryCategory && sound.category ? this.secondaryCategoryChipHtml(sound.category, sound.secondaryCategory) : ''}
         ${sound.license ? this.licenseBadgeHtml(sound.license) : ''}
         <div class="ws-popup-player" id="ws-player-journey-${stepIndex}"></div>
         <div class="journey-nav-buttons">

--- a/src/app/features/map/pages/mapfly/sound-popup-sheet.component.scss
+++ b/src/app/features/map/pages/mapfly/sound-popup-sheet.component.scss
@@ -617,47 +617,6 @@
 }
 
 // =====================
-// Secondary category chip
-// =====================
-.sheet-subcategory-chip {
-  display: inline-flex;
-  align-items: center;
-  align-self: center;
-  gap: 5px;
-  padding: 5px 12px 5px 7px;
-  border-radius: 14px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-decoration: none;
-  cursor: pointer;
-  margin-top: 8px;
-  transition: background 0.15s;
-  background: color-mix(in srgb, var(--chip-color) 10%, transparent);
-  border: 1px solid color-mix(in srgb, var(--chip-color) 18%, transparent);
-  color: color-mix(in srgb, var(--chip-color) 80%, #333);
-
-  .subcategory-chip-icon {
-    width: 20px;
-    height: 20px;
-    object-fit: contain;
-  }
-
-  &:active {
-    background: color-mix(in srgb, var(--chip-color) 20%, transparent);
-  }
-
-  :host-context(body.dark-theme) & {
-    background: color-mix(in srgb, var(--chip-color) 14%, transparent);
-    border-color: color-mix(in srgb, var(--chip-color) 22%, transparent);
-    color: color-mix(in srgb, var(--chip-color) 60%, #ddd);
-
-    &:active {
-      background: color-mix(in srgb, var(--chip-color) 24%, transparent);
-    }
-  }
-}
-
-// =====================
 // License badge
 // =====================
 .sheet-license-badge {
@@ -670,7 +629,7 @@
   border-radius: 10px;
   background: rgba(25, 118, 210, 0.08);
   color: #555;
-  margin-top: 6px;
+  margin-top: 4px;
   cursor: pointer;
   position: relative;
 

--- a/src/app/features/map/pages/mapfly/sound-popup-sheet.component.ts
+++ b/src/app/features/map/pages/mapfly/sound-popup-sheet.component.ts
@@ -239,14 +239,6 @@ export interface SoundPopupSheetData {
           <p class="sheet-record-info" [innerHTML]="recordInfoHtml()"></p>
         }
 
-        <!-- Secondary category chip -->
-        @if (secondaryCategoryLabel()) {
-          <a class="sheet-subcategory-chip" [style.--chip-color]="chipColor()" (click)="navigateToCategory($event)">
-            <img [src]="subcategoryIconSrc()" class="subcategory-chip-icon" alt="" />
-            <span>{{ secondaryCategoryLabel() }}</span>
-          </a>
-        }
-
         <!-- License badge -->
         @if (data.sound.license) {
           <span class="sheet-license-badge" (click)="toggleLicenseTooltip()">
@@ -305,28 +297,6 @@ export class SoundPopupSheetComponent implements AfterViewInit, OnDestroy {
   private radarMap: L.Map | null = null;
   currentZoom = signal(this.data.mapZoom ?? 17);
   showRadar = computed(() => this.currentZoom() >= 5);
-
-  // Secondary category chip
-  private readonly categoryColors: Record<string, string> = {
-    ambiancefly: '#3AE27A', animalfly: '#FF54F9', foodfly: '#E8A849',
-    humanfly: '#FFC1F7', itemfly: '#888888', musicfly: '#D60101',
-    naturalfly: '#39AFF7', sportfly: '#A24C06', transportfly: '#E8D000',
-  };
-
-  secondaryCategoryLabel = computed(() => {
-    const { category, secondaryCategory } = this.data.sound;
-    if (!category || !secondaryCategory) return '';
-    const key = `categories.${category}.${secondaryCategory}`;
-    const t = this.translateService.instant(key);
-    return t !== key ? t : '';
-  });
-
-  chipColor = computed(() => this.categoryColors[this.data.sound.category ?? ''] ?? '#1976d2');
-
-  subcategoryIconSrc = computed(() => {
-    const sc = this.data.sound.secondaryCategory ?? '';
-    return `img/markers/marker_${sc.slice(0, -3)}.png`;
-  });
 
   likeIcon = computed(() =>
     this.isLiked()
@@ -503,16 +473,6 @@ export class SoundPopupSheetComponent implements AfterViewInit, OnDestroy {
     if (!this.data.sound.userId) return;
     const tree = this.router.createUrlTree(['/mapfly'], {
       queryParams: { userId: this.data.sound.userId },
-    });
-    window.location.href = window.location.origin + this.router.serializeUrl(tree);
-  }
-
-  navigateToCategory(event: Event) {
-    event.preventDefault();
-    const { category, secondaryCategory } = this.data.sound;
-    if (!category || !secondaryCategory) return;
-    const tree = this.router.createUrlTree(['/mapfly'], {
-      queryParams: { category, secondaryCategory },
     });
     window.location.href = window.location.origin + this.router.serializeUrl(tree);
   }

--- a/src/app/shared/styles/map.scss
+++ b/src/app/shared/styles/map.scss
@@ -271,53 +271,12 @@
     }
   }
 
-  // Secondary category chip — clickable link to filtered map
-  .popup-subcategory-chip {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 5px;
-    width: fit-content;
-    margin: 6px auto 4px;
-    padding: 4px 10px 4px 6px;
-    border-radius: 12px;
-    font-size: 0.72rem;
-    font-weight: 600;
-    text-decoration: none;
-    cursor: pointer;
-    transition: background 0.15s, transform 0.15s;
-    background: color-mix(in srgb, var(--chip-color) 10%, transparent);
-    border: 1px solid color-mix(in srgb, var(--chip-color) 18%, transparent);
-    color: color-mix(in srgb, var(--chip-color) 80%, #333);
-
-    .subcategory-chip-icon {
-      width: 18px;
-      height: 18px;
-      object-fit: contain;
-    }
-
-    &:hover {
-      background: color-mix(in srgb, var(--chip-color) 18%, transparent);
-      transform: translateY(-1px);
-    }
-
-    body.dark-theme & {
-      background: color-mix(in srgb, var(--chip-color) 14%, transparent);
-      border-color: color-mix(in srgb, var(--chip-color) 22%, transparent);
-      color: color-mix(in srgb, var(--chip-color) 60%, #ddd);
-
-      &:hover {
-        background: color-mix(in srgb, var(--chip-color) 22%, transparent);
-      }
-    }
-  }
-
   .popup-license-badge {
     display: flex;
     align-items: center;
     justify-content: center;
     width: fit-content;
-    margin: 4px auto 12px;
+    margin: 4px auto 8px;
     font-size: 0.7rem;
     font-weight: 600;
     padding: 3px 8px;


### PR DESCRIPTION
Supprime la fonctionnalité de lien cliquable vers la carte filtrée par sous-catégorie dans les popups desktop et le bottom sheet mobile — surcharge visuelle inutile. Nettoie le code TS, HTML et CSS associé.