### PR TITLE
fix: bypass service worker pour les fetch audio S3 (migration + player)

### DIFF
--- a/src/app/core/services/wavesurfer-player.service.ts
+++ b/src/app/core/services/wavesurfer-player.service.ts
@@ -335,8 +335,8 @@ export function createWaveSurferPlayer(config: WaveSurferPlayerConfig): WaveSurf
       chromeFallbackApplied = true;
       (async () => {
         try {
-          // Re-fetch from browser cache + decode at native sample rate
-          const response = await fetch(audioUrl);
+          // Re-fetch from browser cache + decode at native sample rate (bypass service worker)
+          const response = await fetch(audioUrl, { headers: { 'ngsw-bypass': 'true' } });
           const arrayBuffer = await response.arrayBuffer();
           const audioCtx = new AudioContext();
           const fullQualityBuffer = await audioCtx.decodeAudioData(arrayBuffer);

--- a/src/app/features/admin/pages/waveform-migration/waveform-migration.component.ts
+++ b/src/app/features/admin/pages/waveform-migration/waveform-migration.component.ts
@@ -111,8 +111,8 @@ export class WaveformMigrationComponent implements OnDestroy {
           // Get presigned S3 URL
           const url = await this.storageService.getSoundUrl(filename);
 
-          // Fetch the audio file
-          const response = await fetch(url);
+          // Fetch the audio file (bypass Angular service worker to avoid interception errors on large files)
+          const response = await fetch(url, { headers: { 'ngsw-bypass': 'true' } });
           if (!response.ok) {
             throw new Error(`HTTP ${response.status}`);
           }


### PR DESCRIPTION
Le service worker Angular (ngsw) interceptait les requêtes fetch vers S3 et échouait sur les gros fichiers audio en production. Ajout du header ngsw-bypass sur les fetch dans la migration waveform et le fallback Chromium WAV du player.